### PR TITLE
feat(util.js): add function to write ARA identity files to the root ARA folder

### DIFF
--- a/util.js
+++ b/util.js
@@ -74,7 +74,6 @@ async function writeIdentity(identity) {
     throw new TypeError('util.writeIdentity: Expecting files object.')
   }
 
-
   info('Writing New identity: %s to disc', identity.did)
   const hash = toHex(crypto.blake2b(identity.publicKey))
   const output = resolve(rc.network.identity.root, hash)


### PR DESCRIPTION
This PR fixes the issue of missing ARA identity files when using the `create()` method instead of the CLI. 

Once an Identity is created using `create()` method, it can be written into disk by using the `util.writeIdentity()` method

Discussion : The `writeIdentity()` logic could be directly put into the `create()` method as well but it is still up for discussion