### PR TITLE
refactor(create.js): Use random bytes to gen ARAid

### DIFF
--- a/create.js
+++ b/create.js
@@ -47,7 +47,8 @@ async function create(opts) {
     privateKey: wallet.getPrivateKey(),
   })
 
-  const { publicKey, secretKey } = crypto.keyPair(password)
+  const seed = crypto.randomBytes(32)
+  const { publicKey, secretKey } = crypto.keyPair(seed)
 
   const didUri = did.create(publicKey)
   const didDocument = ddo.create({ id: didUri })


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Use random bytes instead of password to generate ARA id