### PR TITLE
feat(keystore/account.js): Changing ethereum account creation

### DIFF
--- a/create.js
+++ b/create.js
@@ -49,9 +49,9 @@ async function create(opts) {
   const { web3 } = context
   const { publicKey, secretKey } = crypto.keyPair(seed)
   const password = crypto.blake2b(Buffer.from(opts.password))
-  const account = await ethereum.account.create({ web3 })
   const { salt, iv } = await ethereum.keystore.create()
   const wallet = await ethereum.wallet.load({ seed })
+  const account = await ethereum.account.create({ web3, privateKey: wallet.getPrivateKey() })
   const kstore = await ethereum.keystore.dump({
     password,
     salt,

--- a/ethereum/account.js
+++ b/ethereum/account.js
@@ -1,4 +1,4 @@
-const { entropy } = require('./entropy')
+const isBuffer = require('is-buffer')
 
 /**
  * Creates an Ethereum account with web3 specified by
@@ -15,10 +15,12 @@ async function create(opts) {
     throw new TypeError('ethereum.account.create: Expecting object.')
   } else if (!opts.web3 || 'object' !== typeof opts.web3) {
     throw new TypeError('ethereum.account.create: Expecting web3 to be an object.')
+  } else if (!opts.privateKey || false === isBuffer(opts.privateKey)) {
+    throw new TypeError('ethereum.account.create: Expecting privateKey to be a buffer')
   }
 
   const { web3 } = opts
-  const account = web3.eth.accounts.create(await entropy(opts.entropy))
+  const account = web3.eth.accounts.privateKeyToAccount(opts.privateKey)
   return account
 }
 

--- a/test/ethereum/account.js
+++ b/test/ethereum/account.js
@@ -1,17 +1,15 @@
 const { create } = require('../../ethereum/account')
 const test = require('ava')
 const Web3 = require('web3')
+const isBuffer = require('is-buffer')
 
 const web3 = new Web3('http://127.0.0.1:9545')
 
 test('ethereum.create({entropy})', async (t) => {
-  await t.throws(create({ web3, entropy: 0 }), TypeError, 'entropy too small')
-  await t.throws(create({ web3, entropy: 1 }), TypeError, 'entropy too small')
-  await t.throws(create({ web3, entropy: -1 }), TypeError, 'entropy too small')
-  await t.throws(create({ web3, entropy: 15 }), TypeError, 'entropy too small')
-  const account = await create({ web3 })
+  await t.throws(create({ web3, privateKey: 0 }), TypeError, 'ethereum.account.create: Expecting privateKey to be a buffer')
+  const account = await create({ web3, privateKey: Buffer.from('b06c21d8e52ce9f89c40695ce79c3349bacf90418f84137220c503d14e2b5e36') })
   t.true(null != account)
   t.true('object' === typeof account)
   t.true('string' === typeof account.address)
-  t.true('string' === typeof account.privateKey)
+  t.true(true === isBuffer(account.privateKey))
 })

--- a/test/ethereum/recover.js
+++ b/test/ethereum/recover.js
@@ -4,7 +4,7 @@ const context = require('ara-context')()
 const test = require('ava')
 
 test('recover(opts)', async (t) => {
-  t.plan(1)
+  t.plan(3)
 
   const mnemonic1 = 'delay blanket scene cactus rare bicycle embark wheel swallow laptop predict moral'
   const password1 = 'hello123'
@@ -21,6 +21,7 @@ test('recover(opts)', async (t) => {
     }
   })
   const privateKey1 = await keystore.recover(password1, keys, encryptedKS)
+  t.true(0 === Buffer.compare(identity1.account.privateKey, privateKey1))
 
   const mnemonic2 = 'delay blanket scene cactus rare bicycle embark wheel swallow laptop predict moral'
   const password2 = 'hello23456'
@@ -35,6 +36,7 @@ test('recover(opts)', async (t) => {
     }
   })
   const privateKey2 = await keystore.recover(password2, keys, encryptedKS)
+  t.true(0 === Buffer.compare(identity2.account.privateKey, privateKey2))
 
   t.true(0 === Buffer.compare(privateKey1, privateKey2))
 })


### PR DESCRIPTION
* This PR changes the way ethereum accounts are created which is to use the privateKey of the HD wallet
