### PR TITLE
refactor(package.json): Move some Ara modules to peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,8 @@
   "author": "Joseph Werle <werle@littlstar.com>",
   "license": "LGPL-3.0",
   "dependencies": {
-    "ara-console": "github:arablocks/ara-console",
     "ara-context": "github:arablocks/ara-context",
-    "ara-crypto": "github:arablocks/ara-crypto",
     "ara-network": "github:arablocks/ara-network",
-    "ara-runtime-configuration": "github:arablocks/ara-runtime-configuration",
     "ara-secret-storage": "github:arablocks/ara-secret-storage",
     "bip39": "^2.5.0",
     "cfsnet": "github:arablocks/cfsnet",
@@ -56,6 +53,11 @@
     "table": "^4.0.3",
     "web3": "^1.0.0-beta.34",
     "yargs": "^11.0.0"
+  },
+  "peerDependencies": {
+    "ara-console": "github:arablocks/ara-console",
+    "ara-crypto": "github:arablocks/ara-crypto",
+    "ara-runtime-configuration": "github:arablocks/ara-runtime-configuration"
   },
   "devDependencies": {
     "ava": "^0.25.0",


### PR DESCRIPTION
Fixes # N/A

## Proposed Changes

  - Move ara-console, ara-crypto, and ara-runtime-configuration to peerDependencies