### PR TITLE
feat(archive.js): Fix destroy function and timeout

### DIFF
--- a/archive.js
+++ b/archive.js
@@ -95,7 +95,7 @@ async function archive(identity, opts) {
   return true
 
   function onpeer(connection, peer) {
-    //timeout = setTimeout(ontimeout, opts.timeout || 5000)
+    // timeout = setTimeout(ontimeout, opts.timeout || 5000)
     const socket = net.connect(peer.port, peer.host)
     const handshake = new Handshake({
       publicKey,


### PR DESCRIPTION
* This PR fixes the minor bug with `channel.destroy()`. Also, the 2nd timeout isn't getting cleared properly. Disabling it for now to avoid blocking other modules from porting to the new `archive()` method
* The timeout functionality for the handshake process in `onpeer()` will be added in an upcoming PR