### PR TITLE
feat(bin/ara-identity): Add `recover` to the aid CLI

### DIFF
--- a/bin/ara-identity
+++ b/bin/ara-identity
@@ -154,7 +154,7 @@ program.command(
   // eslint-disable-next-line no-shadow
   program => program
     .usage('usage: $0 [-D] recover')
-    .group([ 'mnemonic' ], 'Recover Options:')
+    .group([ 'mnemonic' ], 'Recovery Options:')
     .option('mnemonic', {
       alias: 'm',
       describe: 'Valid bip39 mnemonic',
@@ -183,16 +183,13 @@ if (program.argv.debug) {
 async function onrecover(argv) {
   const { mnemonic } = argv
 
-  info('Recovering identity for the mnemonic')
-  info('\n\n%s', table([ [ mnemonic ] ]))
-
   let { password } = await inquirer.prompt([ {
     type: 'password',
     name: 'password',
     message:
     'Please provide a new passphrase for the identity being recovered. This would be needed to ' +
     'archive your recovered identity.\n' +
-    'Passphrase:\n'
+    'Passphrase:'
   } ])
 
   if (!password) {
@@ -202,15 +199,15 @@ async function onrecover(argv) {
   }
 
   try{
-    const identity = await aid.recover({context, password, mnemonic})
-    info('Ara Identity recovered : %s', identity.did)
+    const identity = await aid.recover({ context, password, mnemonic })
+    info('Identity recovered : %s', identity.did)
 
     for (let i = 0; i < identity.files.length; ++i) {
       warn('Will write identity file: %s', identity.files[i].path)
     }
 
     await writeIdentity(identity)
-    info('Identity recovered successfully!!!')
+    info('Identity recovered successfully.')
   } catch(err) {
     onfatal(err)
   }


### PR DESCRIPTION
* This PR adds the `recover()` method to the `ara-identity` or `aid` CLI
* The recover method takes in a bip39 mnemonic and recreates an Ara Identity
* The recover method also requires the user to input a new passphrase to be used with the recovered Ara identity