### PR TITLE
feat(archive/resolve): added keyringOpts extraction from ararc

### DIFF
--- a/archive.js
+++ b/archive.js
@@ -32,10 +32,9 @@ async function archive(identity, opts) {
   if (null == opts || 'object' !== typeof opts) {
     throw new TypeError('Expecting options to be an object.')
   }
-  
+
   let conf
-  try { conf = rc.network.identity.archiver }
-  finally { conf = conf || {} }
+  try { conf = rc.network.identity.archiver } finally { conf = conf || {} }
   opts.secret = opts.secret || conf.secret
   opts.keyring = opts.keyring || conf.keyring
   opts.network = opts.network || conf.network

--- a/resolve.js
+++ b/resolve.js
@@ -28,8 +28,7 @@ async function resolve(uri, opts) {
   }
 
   let conf
-  try { conf = rc.network.identity.resolver }
-  finally { conf = conf || {} }
+  try { conf = rc.network.identity.resolver } finally { conf = conf || {} }
   opts.secret = opts.secret || conf.secret
   opts.keyring = opts.keyring || conf.keyring
   opts.network = opts.network || conf.network


### PR DESCRIPTION
## Proposed Changes

  - extract keyring opts from .ararc files

Example Windows .ararc:
```
[network.identity.resolver]
secret = test-node
keyring = C:/Users/brand/.ara/keyrings/aws-test.pub
network = resolver

[network.identity.archiver]
secret = test-node
keyring = C:/Users/brand/.ara/keyrings/aws-test.pub
network = archiver
```

Example Mac .ararc:
```
[network.identity.resolver]
secret = test-node
keyring = /Users/brand/.ara/keyrings/aws-test.pub
network = resolver

[network.identity.archiver]
secret = test-node
keyring = /Users/brand/.ara/keyrings/aws-test.pub
network = archiver
```