### PR TITLE
feat(archive): ability to shallow archive just a ddo

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ const identity = await aid.create(opts)
 const archiverOpts = {
   secret: 'test-secret',
   network: 'test-archiver',
-  keyring: '~/.ara/keyrings/keyring.pub'
+  keyring: '~/.ara/keyrings/keyring.pub',
+  shallow: true
 }
 
 await aid.archive(identity, archiverOpts)

--- a/archive.js
+++ b/archive.js
@@ -21,16 +21,13 @@ const kDefaultTimeout = 5000
  * @param {String|Buffer} opts.secret
  * @param {String} opts.keyring
  * @param {String} opts.network
+ * @param {Boolean} opts.shallow
  * @throws TypeError
  * @return {Promise}
  */
-async function archive(identity, opts) {
+async function archive(identity, opts = {}) {
   if (null == identity || 'object' !== typeof identity) {
     throw new TypeError('Expecting identity to be an object.')
-  }
-
-  if (null == opts || 'object' !== typeof opts) {
-    throw new TypeError('Expecting options to be an object.')
   }
 
   let conf
@@ -82,7 +79,10 @@ async function archive(identity, opts) {
     id: toHex(publicKey),
   })
 
-  await Promise.all(files.map(file => cfs.writeFile(file.path, file.buffer)))
+  const shallow = opts.shallow || false
+  await Promise.all(files.map(file => {
+    if (!shallow || 'ddo.json' === file.path) cfs.writeFile(file.path, file.buffer)
+  }))
 
   const secret = Buffer.from(opts.secret)
   const keyring = keyRing(opts.keyring, { secret })


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Shallow archive with just ddo
  - Archive without passing opts (since we default them anyway)
  -