### PR TITLE
feat(.): Implement porcelain 'aid.save()'

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ All functions check for input validity, input correctness, and throw an error if
 
 * [aid.archive(identity, opts)](#archive)
 * [aid.create(opts)](#create)
+* [aid.save(identity)](#save)
 * [aid.createIdentityKeyPath(identity)](#createIdPath)
 * [aid.did.create(publicKey)](#didCreate)
 * [aid.did.normalize(identifier, method)](#didNormalize)
@@ -125,6 +126,23 @@ const opts = {
 }
 
 const identity = await aid.create(opts)
+```
+
+<a name="save"></a>
+### `aid.save(identity)`
+Save an Ara identity to disk. Does not work in browser.
+```js
+const context = require('ara-context')()
+
+const opts = {
+  context,
+  password: 'hello'
+}
+
+const identity = await aid.create(opts)
+if (await aid.save(identity)) {
+  console.log(await aid.resolve(identity))
+}
 ```
 
 <a name="createIdPath"></a>

--- a/create.js
+++ b/create.js
@@ -78,7 +78,7 @@ async function create(opts) {
     }
 
     if (opts.ddo.publicKey && !Array.isArray(opts.ddo.publicKey)) {
-      opts.ddo.publicKey = [opts.ddo.publicKey]
+      opts.ddo.publicKey = [ opts.ddo.publicKey ]
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const { resolve } = require('./resolve')
 const { recover } = require('./recover')
 const { revoke } = require('./revoke')
 const { create } = require('./create')
+const { save } = require('./save')
 const ethereum = require('./ethereum')
 const { list } = require('./list')
 const util = require('./util')
@@ -19,6 +20,7 @@ module.exports = {
   resolve,
   revoke,
   create,
+  save,
   list,
   util,
   ddo,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "extend": "^3.0.1",
     "got": "^8.3.1",
     "inquirer": "^5.2.0",
-    "is-browser": "^2.0.1",
+    "is-browser": "^2.1.0",
     "is-buffer": "^2.0.2",
     "is-zero-buffer": "^1.0.1",
     "keythereum": "^1.0.4",

--- a/resolve.js
+++ b/resolve.js
@@ -33,6 +33,15 @@ async function resolve(uri, opts = {}) {
   opts.keyring = opts.keyring || conf.keyring
   opts.network = opts.network || conf.network
 
+  // is DID ?
+  if (uri && 'object' === typeof uri && uri.did) {
+    if ('string' === typeof uri.did) {
+      uri = uri.did
+    } else if ('object' === typeof uri.did) {
+      uri = uri.did.reference
+    }
+  }
+
   if (0 !== uri.indexOf('did:ara:')) {
     // eslint-disable-next-line no-param-reassign
     uri = `did:ara:${uri}`

--- a/save.js
+++ b/save.js
@@ -1,0 +1,19 @@
+const { writeIdentity } = require('./util')
+const isBrowser = require('is-browser')
+
+/**
+ * High level function to save an identity to disk
+ */
+async function save(identity) {
+  // @TODO(werle): Handle browser case for saving
+  if (false === isBrowser) {
+    await writeIdentity(identity)
+    return true
+  }
+
+  return false
+}
+
+module.exports = {
+  save
+}

--- a/util.js
+++ b/util.js
@@ -84,7 +84,6 @@ async function writeIdentity(identity) {
       identity.files[i].buffer
     )
   }
-  return null
 }
 
 module.exports = {


### PR DESCRIPTION
## Proposed Changes

  - Wrap `writeIdentity` in module level `aid.save()` function so people don't have to use it awkwardly anymore: 

```js
const identity = await aid.create({ context, password })
await writeIdentity(identity)
const { publicKey: owner } = identity
const { afs } = await create({ owner, password })
```